### PR TITLE
README: "git clone" step error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [Node.js](http://nodejs.org/).*
 
 * Fork this repository.
-* `$ git clone git@github.com/<GitHub-username>/lima.git`
+* `$ git clone git@github.com:<GitHub-username>/lima.git`
 * `$ virtualenv venv`
 * `$ source venv/bin/activate`
 * `$ pip install -r requirements.txt`


### PR DESCRIPTION
Mistake in the "git clone" step.

Edited the first "/" after "git@github.com" to ":".